### PR TITLE
Fix dump_external_process test

### DIFF
--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -301,7 +301,7 @@ mod windows {
         Foundation::CloseHandle,
         System::{
             Diagnostics::Debug::{GetThreadContext, CONTEXT, EXCEPTION_POINTERS, EXCEPTION_RECORD},
-            Threading::{GetCurrentThreadId, OpenThread, THREAD_ALL_ACCESS},
+            Threading::{GetCurrentProcessId, GetCurrentThreadId, OpenThread, THREAD_ALL_ACCESS},
         },
     };
 
@@ -317,6 +317,7 @@ mod windows {
             exception_context.ContextFlags =
                 minidump_common::format::ContextFlagsAmd64::CONTEXT_AMD64_ALL.bits();
 
+            let pid = GetCurrentProcessId();
             let tid = GetCurrentThreadId();
 
             let thread_handle = OpenThread(THREAD_ALL_ACCESS, 0, tid);
@@ -332,7 +333,7 @@ mod windows {
 
             let exc_ptr_addr = &exception_ptrs as *const _ as usize;
 
-            println!("{exc_ptr_addr} {tid} {exception_code:x}");
+            println!("{pid} {exc_ptr_addr} {tid} {exception_code:x}");
 
             // Wait until we're killed
             loop {

--- a/tests/windows_minidump_writer.rs
+++ b/tests/windows_minidump_writer.rs
@@ -87,7 +87,7 @@ fn dump_external_process() {
 
     let mut child = start_child_and_return(&format!("{:x}", EXCEPTION_ILLEGAL_INSTRUCTION));
 
-    let (exception_pointers, thread_id, exception_code) = {
+    let (process_id, exception_pointers, thread_id, exception_code) = {
         let mut f = std::io::BufReader::new(child.stdout.as_mut().expect("Can't open stdout"));
         let mut buf = String::new();
         f.read_line(&mut buf).expect("failed to read stdout");
@@ -95,11 +95,12 @@ fn dump_external_process() {
 
         let mut biter = buf.trim().split(' ');
 
+        let process_id: u32 = biter.next().unwrap().parse().unwrap();
         let exception_pointers: usize = biter.next().unwrap().parse().unwrap();
         let thread_id: u32 = biter.next().unwrap().parse().unwrap();
         let exception_code = u32::from_str_radix(biter.next().unwrap(), 16).unwrap() as i32;
 
-        (exception_pointers, thread_id, exception_code)
+        (process_id, exception_pointers, thread_id, exception_code)
     };
 
     assert_eq!(exception_code, EXCEPTION_ILLEGAL_INSTRUCTION);
@@ -115,7 +116,7 @@ fn dump_external_process() {
         .tempfile()
         .unwrap();
 
-    let dumper = MinidumpWriter::external_process(crash_context, child.id())
+    let dumper = MinidumpWriter::external_process(crash_context, process_id)
         .expect("failed to create MinidumpWriter");
 
     dumper

--- a/tests/windows_minidump_writer.rs
+++ b/tests/windows_minidump_writer.rs
@@ -135,6 +135,6 @@ fn dump_external_process() {
 
     assert_eq!(
         crash_reason,
-        CrashReason::from_windows_error(EXCEPTION_ILLEGAL_INSTRUCTION as u32)
+        CrashReason::from_windows_code(EXCEPTION_ILLEGAL_INSTRUCTION as u32)
     );
 }


### PR DESCRIPTION
Hey @Jake-Shadle 

I figured out what the issue was with the test. This is probably one of those "You're going to groan when you hear the reason"  situations, unfortunately...

So... When you use `start_child_and_return()` at the beginning of the test, that runs `cargo run --bin test`, which builds the `test.exe` and runs it.

So when you were using `child.id()` later in the parent, you were passing the process id of Cargo and not the `test.exe` file.

This fixes it by having the child process pass its actual `pid` through `stdout` along with that other info you already coded.

After that, there was also a minor issue where `CrashReason::from_windows_error()` was being used, but for exceptions we should use `CrashReason::from_windows_code()`. Quick fix 😀

Once this is merged into your main, I think that will be everything needed to get your main merged upstream :)